### PR TITLE
Add a typealias for State to work around type lookup issue

### DIFF
--- a/PullToRefresh/State.swift
+++ b/PullToRefresh/State.swift
@@ -34,3 +34,5 @@ public func ==(a: State, b: State) -> Bool {
     default: return false
     }
 }
+
+public typealias PullToRefreshState = State


### PR DESCRIPTION
If the current module already has a type named `State`, it can become impossible to refer to `PullToRefresh.State`, and thus impossible to implement `RefreshViewAnimator`. ([Swift bug SR-898](https://bugs.swift.org/browse/SR-898))

As a workaround, `PullToRefresh.State` is now also known as `PullToRefreshState`, which is less likely to conflict.

(This is only an issue because there is a type named `PullToRefresh` in the module called `PullToRefresh`, but this `typealias` seemed the more sensible fix.)